### PR TITLE
Fix constructor params usage

### DIFF
--- a/2013/07/WebAudio.md
+++ b/2013/07/WebAudio.md
@@ -122,12 +122,15 @@ function playSound() {
     oneShotSound.buffer = dogBarkingBuffer;
 
     // Create a filter, panner, and gain node. 
+    
     var lowpass = context.createBiquadFilter();
-    var panner = context.createPanner({ 
-      panningModel: "equalpoewr",
-      distanceModel: "linear"
-    });
+
+    var panner = context.createPanner();
+    panner.panningModel = "equalpower";
+    panner.distanceModel = "linear";
+
     var gainNode2 = context.createGain();
+    
 
     // Make connections 
     oneShotSound.connect(lowpass);
@@ -151,7 +154,10 @@ function playSound() {
 
     // Create a filter, panner, and gain node. 
     var lowpass = new BiquadFilterNode(context);
-    var panner = new PannerNode(context);
+    var panner = new PannerNode(context, { 
+      panningModel: "equalpower",
+      distanceModel: "linear"
+    });
     var gainNode2 = new GainNode(context);
 
     // Make connections 


### PR DESCRIPTION
The existing-code example used parameters of `createPannerNode` that don't exist, whereas the new-code example didn't use the proposed attributes parameter.
