### PR TITLE
Encourage feature owners to list all relevant standards groups.

### DIFF
--- a/.github/ISSUE_TEMPLATE/005-early-design-review.md
+++ b/.github/ISSUE_TEMPLATE/005-early-design-review.md
@@ -22,26 +22,26 @@ I'm requesting an early TAG design review of {{feature}}.
       - $name (@-mention), $organization/s, $role in developing specification
       - {{repeat as necessary, we recommend including group chairs and editors in this list}}
   - Organization/project driving the design:
+  - This work is being funded by:
+  - Incubation and standards groups that have discussed the design:
+    - {{ABC CG}} <!-- Include a link to minutes or issues in this group if possible. -->
+    - {{DEF WG}}
+  - Standards group(s) that you expect to discuss and/or adopt this work when it's
+    ready: <!-- "unknown" if not known -->
   - Multi-stakeholder feedback³:
     - Chromium comments:
-    - Mozilla comments: https://github.com/mozilla/standards-positions/issues/NNN
-    - WebKit comments: https://github.com/WebKit/standards-positions/issues/NNN
+    - Mozilla comments: https://github.com/mozilla/standards-positions/issues/NNN <!-- And/or other places they've given feedback -->
+    - WebKit comments: https://github.com/WebKit/standards-positions/issues/NNN <!-- And/or other places they've given feedback -->
     - {{...include feedback/review from developers, implementers, civil society, and others}}
-
-Further details:
+  - Major unresolved issues with or opposition to this design:
 
   - [ ] I have reviewed the TAG's [Web Platform Design Principles](https://www.w3.org/TR/design-principles/)
-  - The group where the incubation/design work on this is being done (or is intended to be done in the future):
-  - The group where standardization of this work is intended to be done ("unknown" if not known):
-  - Existing major pieces of multi-implementer review or discussion of this design:
-  - Major unresolved issues with or opposition to this design:
-  - This work is being funded by:
 
 You should also know that...
 
 {{Please tell us anything else you think is relevant to this review.}}
 
-------------------------------------------------------------------------------------
+<!------------------------------------------------------------------------------------
 CAREFULLY READ AND DELETE CONTENT BELOW THIS LINE BEFORE SUBMITTING
 
 Use links to content rather than pasting text into this issue. Issues are ephemeral and most of the material we are asking for has long term value.
@@ -53,3 +53,5 @@ Please preview the issue and check that the links work before submitting. Please
 ² Even for early-stage ideas, a Security and Privacy questionnaire helps us understand potential security and privacy issues and mitigations for your design, and can save us asking redundant questions. See https://www.w3.org/TR/security-privacy-questionnaire/.
 
 ³ For your own organization, you can simply state the organization's position instead of linking to it.  This includes items on [Mozilla standards-positions](https://github.com/mozilla/standards-positions), and [WebKit standards-positions](https://github.com/WebKit/standards-positions).  Chromium doesn't have a standards-positions repository and [prefers](https://source.chromium.org/chromium/chromium/src/+/main:docs/standards/positions/GoogleChrome/README.md) to use comments from the teams that maintain the relevant area of their codebase.
+
+-->

--- a/.github/ISSUE_TEMPLATE/010-specification-review.md
+++ b/.github/ISSUE_TEMPLATE/010-specification-review.md
@@ -24,11 +24,18 @@ I'm requesting a TAG review of {{feature}}.
       - $name (@-mention), $organization/s, $role in developing specification
       - {{repeat as necessary, we recommend including group chairs and editors in this list}}
   - Organization/project driving the specification:
+  - This work is being funded by:
+  - Primary standards group developing this feature:
+  - Group intended to standardize this work: <!-- if different from the current group -->
+  - Incubation and standards groups that have discussed the design:
+    - {{ABC CG}} <!-- Include a link to minutes or issues in this group if possible. -->
+    - {{DEF WG}}
   - Multi-stakeholder support³:
     - Chromium comments:
-    - Mozilla comments: https://github.com/mozilla/standards-positions/issues/NNN
-    - WebKit comments: https://github.com/WebKit/standards-positions/issues/NNN
+    - Mozilla comments: https://github.com/mozilla/standards-positions/issues/NNN <!-- And/or other places they've given feedback -->
+    - WebKit comments: https://github.com/WebKit/standards-positions/issues/NNN <!-- And/or other places they've given feedback -->
     - {{...include feedback/review from developers, implementers, civil society, and others}}
+  - Major unresolved issues with or opposition to this specification:
   - Status/issue trackers for implementations⁴:
 
 Further details:
@@ -36,16 +43,12 @@ Further details:
   - [ ] I have reviewed the TAG's [Web Platform Design Principles](https://www.w3.org/TR/design-principles/)
   - Previous early design review, if any: https://github.com/w3ctag/design-reviews/issues/####
   - Relevant time constraints or deadlines:
-  - The group where the work on this specification is currently being done:
-  - The group where standardization of this work is intended to be done (if different from the current group):
-  - Major unresolved issues with or opposition to this specification:
-  - This work is being funded by:
 
 You should also know that...
 
 {{Please tell us anything else you think is relevant to this review.}}
 
-------------------------------------------------------------------------------------
+<!------------------------------------------------------------------------------------
 CAREFULLY READ AND DELETE CONTENT BELOW THIS LINE BEFORE SUBMITTING
 
 Use links to content rather than pasting text into this issue. Issues are ephemeral and most of the material we are asking for has long term value.
@@ -59,3 +62,5 @@ Please preview the issue and check that the links work before submitting. Please
 ³ For your own organization, you can simply state the organization's position instead of linking to it.  This includes items on [Mozilla standards-positions](https://github.com/mozilla/standards-positions), and [WebKit standards-positions](https://github.com/WebKit/standards-positions).  Chromium doesn't have a standards-positions repository and [prefers](https://source.chromium.org/chromium/chromium/src/+/main:docs/standards/positions/GoogleChrome/README.md) to use comments from the teams that maintain the relevant area of their codebase.
 
 ⁴ Include links to [Chrome Status](https://chromestatus.com/), [Mozilla's](https://bugzilla.mozilla.org/), [WebKit's Bugzilla](https://bugs.webkit.org/), and trackers for other implementations if those are known to you.
+
+-->


### PR DESCRIPTION
And move most questions out of the "Further details" section.


This is meant to avoid the questions of whether particular WGs were consulted that came up in https://github.com/w3ctag/design-reviews/issues/1015#issuecomment-2577114166.