### PR TITLE
Add an accessibility self-review to TAG design reviews.

### DIFF
--- a/.github/ISSUE_TEMPLATE/005-early-design-review.md
+++ b/.github/ISSUE_TEMPLATE/005-early-design-review.md
@@ -17,6 +17,7 @@ I'm requesting an early TAG design review of {{feature}}.
   - Explainer¹:
   - User research:
   - Security and Privacy self-review²:
+  - Accessibility self-review: <!-- If the feature adds any visual or audible user interface, passes visual or audible data through a protocol, or changes anything about user input, copy the checklist from https://w3c.github.io/fast/checklist.html into your repository, fill it out, and link to it here. Otherwise replace this with "N/A". -->
   - GitHub repo:
   - Primary contacts:
       - $name (@-mention), $organization/s, $role in developing specification

--- a/.github/ISSUE_TEMPLATE/010-specification-review.md
+++ b/.github/ISSUE_TEMPLATE/010-specification-review.md
@@ -19,6 +19,7 @@ I'm requesting a TAG review of {{feature}}.
   - WPT Tests:
   - User research:
   - Security and Privacy self-review²:
+  - Accessibility self-review: <!-- If the feature adds any visual or audible user interface, passes visual or audible data through a protocol, or changes anything about user input, copy the checklist from https://w3c.github.io/fast/checklist.html into your repository, fill it out, and link to it here. Otherwise replace this with "N/A". -->
   - GitHub repo:
   - Primary contacts:
       - $name (@-mention), $organization/s, $role in developing specification


### PR DESCRIPTION
@matatk Is https://w3c.github.io/fast/checklist.html the right questionnaire to ask people to fill out? I think I'd like to wait to merge this until there's a markdown template for people to copy, like with https://github.com/w3c/security-questionnaire/blob/main/questionnaire.markdown. Then I also want to get some folks who propose HTML and CSS features to review that checklist to ensure that it's not too much of a burden to fill it out.